### PR TITLE
feat: Restructure advantages and spheres layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -89,17 +89,26 @@ section {
     gap: 20px;
 }
 
-.advantages {
+.spheres-grid {
     display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 20px;
-    padding-right: 20px;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0 20px;
 }
 
-.lower-sheet-grid {
+.advantages-grid {
     display: grid;
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 30px;
+    align-items: start;
+}
+
+.advantage-column {
+    display: flex;
+    flex-direction: column;
     gap: 20px;
+}
+
+.other-traits-title {
     margin-top: 20px;
 }
 

--- a/index.html
+++ b/index.html
@@ -88,18 +88,24 @@
             </div>
         </section>
 
-        <div class="lower-sheet-grid">
-            <section>
-                <h2>Vantagens</h2>
-                <div class="advantages">
-                    <div class="advantage-group">
-                        <h3>Antecedentes</h3>
-                        <div id="backgrounds"><!-- Gerado por JS --></div>
-                    </div>
-                     <div class="advantage-group">
-                        <h3>Esferas</h3>
-                        <div id="spheres"><!-- Gerado por JS --></div>
-                    </div>
+        <section>
+            <h2>Esferas</h2>
+            <div id="spheres" class="spheres-grid">
+                <!-- Gerado por JS -->
+            </div>
+        </section>
+
+        <section>
+            <h2>Vantagens</h2>
+            <div class="advantages-grid">
+                <div class="advantage-group">
+                    <h3>Antecedentes</h3>
+                    <div id="backgrounds"><!-- Gerado por JS --></div>
+                    <h3 class="other-traits-title">Outras Características</h3>
+                    <div id="other-traits"><!-- Gerado por JS --></div>
+                </div>
+
+                <div class="advantage-column">
                     <div class="advantage-group">
                         <h3>Arete</h3>
                         <div id="arete"><!-- Gerado por JS --></div>
@@ -108,24 +114,16 @@
                         <h3>Força de Vontade</h3>
                         <div id="willpower"><!-- Gerado por JS --></div>
                     </div>
+                    <div class="advantage-group">
+                        <h3>Quintessência</h3>
+                        <div id="quintessence"><!-- Gerado por JS --></div>
+                    </div>
                 </div>
-            </section>
 
-            <section id="health">
-                <h2>Vitalidade</h2>
-                <!-- Gerado por JS -->
-            </section>
-        </div>
-
-        <section id="other-traits">
-            <h2>Outras Características</h2>
-            <!-- Gerado por JS -->
-        </section>
-
-        <section class="quintessence-section">
-            <h2>Quintessência</h2>
-            <div id="quintessence">
-                <!-- Gerado por JS -->
+                <div class="advantage-group">
+                    <h3>Vitalidade</h3>
+                    <div id="health"><!-- Gerado por JS --></div>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
This commit refactors the layout of the character sheet to match the user's request.

The 'Esferas' (Spheres) section is now displayed above the 'Vantagens' (Advantages) section and is organized in a 3-column grid.

The 'Vantagens' section has been restructured into a 3-column layout to group 'Antecedentes', 'Arete', 'Força de Vontade', and 'Vitalidade' in a more organized way, similar to the provided image.