### PR TITLE
feat: Update styling for Arete, Willpower, and Quintessence

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -19,6 +19,26 @@
     border-color: #3a2d21;
 }
 
+.checkbox-marker {
+    width: 14px;
+    height: 14px;
+    border: 1px solid #3a2d21;
+    display: inline-block;
+    margin-left: 5px;
+    cursor: pointer;
+    transition: background-color 0.2s ease-in-out;
+    background-color: #fff;
+}
+
+.checkbox-marker:hover {
+    background-color: #e0d8c4;
+}
+
+.checkbox-marker.filled {
+    background-color: #3a2d21;
+    border-color: #3a2d21;
+}
+
 /* Health Track Styles */
 .health-level {
     display: flex;
@@ -60,12 +80,26 @@
     color: #3a2d21;
 }
 
+.checkbox-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: center;
+    margin-top: 10px;
+}
+
 /* Trait Block Styles */
 .trait {
     display: flex;
     justify-content: space-between;
     align-items: center;
     margin-bottom: 8px;
+}
+
+.trait.vertical-trait {
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
 }
 
 .trait-label, .trait-input {

--- a/assets/js/components/attributeBlock.js
+++ b/assets/js/components/attributeBlock.js
@@ -6,7 +6,7 @@
  * @param {number} [dotCount=5] - The total number of dots for each trait.
  * @param {number} [initialValue=1] - The number of dots that should be pre-filled.
  */
-function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, dataPath = null) {
+function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, dataPath = null, options = {}) {
     const targetElement = document.getElementById(targetId);
 
     if (!targetElement) {
@@ -18,11 +18,15 @@ function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, 
     targetElement.innerHTML = '';
 
     const fragment = document.createDocumentFragment();
+    const { markerType = 'dots', customClass = '' } = options;
 
     for (const name of traitNames) {
         // Create the main container for the trait
         const traitDiv = document.createElement('div');
         traitDiv.className = 'trait';
+        if (customClass) {
+            traitDiv.classList.add(customClass);
+        }
 
         // Add data attributes for easy mapping back to the data model
         if (dataPath) {
@@ -45,25 +49,29 @@ function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, 
             nameElement.textContent = name;
         }
 
-        // Create the dots container
-        const dotsDiv = document.createElement('div');
-        dotsDiv.className = 'dots';
+        // Create the markers container
+        const markersDiv = document.createElement('div');
+        markersDiv.className = 'dots'; // Keep class for styling consistency
 
-        // Create the individual dots
+        // Create the individual markers (dots or checkboxes)
         for (let i = 1; i <= dotCount; i++) {
-            const dot = document.createElement('span');
-            dot.className = 'dot';
+            const marker = document.createElement(markerType === 'checkbox' ? 'div' : 'span');
+            marker.className = markerType === 'checkbox' ? 'checkbox-marker' : 'dot';
+
+            // Add a common class for event handling
+            marker.classList.add('marker');
+
             if (i <= initialValue) {
-                dot.classList.add('filled');
+                marker.classList.add('filled');
             }
             // Add data-value for later use in event handling
-            dot.dataset.value = i;
-            dotsDiv.appendChild(dot);
+            marker.dataset.value = i;
+            markersDiv.appendChild(marker);
         }
 
         // Assemble the trait element
         traitDiv.appendChild(nameElement);
-        traitDiv.appendChild(dotsDiv);
+        traitDiv.appendChild(markersDiv);
 
         // Add the complete trait to the document fragment
         fragment.appendChild(traitDiv);

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -23,15 +23,18 @@ function initializeSheet() {
     createTraitBlock('spheres', Object.keys(characterData.advantages.spheres), 5, 0, { category: 'advantages', group: 'spheres' });
 
     // Other Traits that don't have a "group"
-    createTraitBlock('arete', ['Arete'], 10, 1, { category: 'advantages' });
-    createTraitBlock('willpower', ['Força de Vontade'], 10, 1, { category: 'advantages' });
-    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages' });
+    createTraitBlock('arete', ['Arete'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
+    createTraitBlock('willpower', ['Força de Vontade'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
+    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages' }, { markerType: 'checkbox', customClass: 'vertical-trait' });
 
     // Health Track
     createHealthTrack('health', characterData.health);
 
     // Other Traits
     createBlankLines('other-traits', 4);
+
+    // Add temporary willpower checkboxes
+    createCheckboxGrid('willpower-temporary', 10);
 }
 
 /**
@@ -42,7 +45,7 @@ function setupEventListeners() {
     if (!sheet) return;
 
     sheet.addEventListener('click', (event) => {
-        if (event.target.classList.contains('dot')) {
+        if (event.target.classList.contains('marker')) {
             handleDotClick(event.target);
         } else if (event.target.classList.contains('health-box')) {
             handleHealthBoxClick(event.target);
@@ -59,20 +62,20 @@ function handleDotClick(clickedDot) {
     if (!traitDiv) return;
 
     const dotsContainer = clickedDot.parentElement;
-    const allDots = dotsContainer.querySelectorAll('.dot');
+    const allMarkers = dotsContainer.querySelectorAll('.marker');
     const clickedValue = parseInt(clickedDot.dataset.value, 10);
     const nameElement = traitDiv.querySelector('.trait-label') || traitDiv.querySelector('.trait-input');
     const traitName = nameElement.tagName === 'LABEL' ? nameElement.textContent : nameElement.value;
 
     const { category, group } = traitDiv.dataset;
 
-    const currentValue = Array.from(allDots).filter(d => d.classList.contains('filled')).length;
+    const currentValue = Array.from(allMarkers).filter(d => d.classList.contains('filled')).length;
     const newValue = (clickedValue === currentValue) ? clickedValue - 1 : clickedValue;
 
     // Update UI
-    allDots.forEach(dot => {
-        const dotValue = parseInt(dot.dataset.value, 10);
-        dot.classList.toggle('filled', dotValue <= newValue);
+    allMarkers.forEach(marker => {
+        const markerValue = parseInt(marker.dataset.value, 10);
+        marker.classList.toggle('filled', markerValue <= newValue);
     });
 
     // Update Data Model
@@ -151,6 +154,29 @@ function createHealthTrack(targetId, healthLevels) {
     });
 
     targetElement.appendChild(fragment);
+}
+
+/**
+ * Creates a grid of checkboxes.
+ * @param {string} targetId - The ID of the container element.
+ * @param {number} count - The number of checkboxes to create.
+ */
+function createCheckboxGrid(targetId, count) {
+    const targetElement = document.getElementById(targetId);
+    if (!targetElement) return;
+
+    const container = document.createElement('div');
+    container.className = 'checkbox-grid';
+
+    for (let i = 0; i < count; i++) {
+        const box = document.createElement('div');
+        box.className = 'checkbox-marker';
+        // Note: These are not connected to the data model for now.
+        // They can be made interactive by adding event listeners similar to handleDotClick.
+        container.appendChild(box);
+    }
+
+    targetElement.appendChild(container);
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
                     <div class="advantage-group">
                         <h3>Força de Vontade</h3>
                         <div id="willpower"><!-- Gerado por JS --></div>
+                        <div id="willpower-temporary"></div>
                     </div>
                     <div class="advantage-group">
                         <h3>Quintessência</h3>


### PR DESCRIPTION
This commit implements several styling and layout updates based on user feedback:

1.  The `createTraitBlock` component is enhanced to support different marker types (dots or checkboxes) and custom CSS classes.
2.  The traits for Arete, Willpower, and Quintessence are updated to use a vertical layout where the markers appear below the trait name.
3.  Quintessence now uses square checkboxes instead of dots for its markers.
4.  An additional 10 temporary square checkboxes are added below the Willpower trait.