### PR TITLE
feat: Implement circular layout and other styling adjustments

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -82,10 +82,22 @@
 
 .checkbox-grid {
     display: flex;
-    flex-wrap: wrap;
     gap: 4px;
     justify-content: center;
     margin-top: 10px;
+}
+
+.centered-title {
+    text-align: center;
+}
+
+.circular-container {
+    position: relative;
+    width: 180px;
+    height: 180px;
+    margin: 20px auto;
+    padding: 0;
+    border-radius: 50%;
 }
 
 /* Trait Block Styles */

--- a/assets/js/components/attributeBlock.js
+++ b/assets/js/components/attributeBlock.js
@@ -18,7 +18,7 @@ function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, 
     targetElement.innerHTML = '';
 
     const fragment = document.createDocumentFragment();
-    const { markerType = 'dots', customClass = '' } = options;
+    const { markerType = 'dots', customClass = '', layout = 'linear' } = options;
 
     for (const name of traitNames) {
         // Create the main container for the trait
@@ -52,6 +52,9 @@ function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, 
         // Create the markers container
         const markersDiv = document.createElement('div');
         markersDiv.className = 'dots'; // Keep class for styling consistency
+        if (layout === 'circular') {
+            markersDiv.classList.add('circular-container');
+        }
 
         // Create the individual markers (dots or checkboxes)
         for (let i = 1; i <= dotCount; i++) {
@@ -66,6 +69,19 @@ function createTraitBlock(targetId, traitNames, dotCount = 5, initialValue = 1, 
             }
             // Add data-value for later use in event handling
             marker.dataset.value = i;
+
+            if (layout === 'circular') {
+                const angle = (360 / dotCount) * i;
+                const radius = 80; // pixels
+                marker.style.position = 'absolute';
+                // To position from the center of the container, we set top and left to 50%
+                marker.style.top = '50%';
+                marker.style.left = '50%';
+                // We use a margin to offset the marker's own size before transforming
+                marker.style.margin = '-8px'; // Half of marker size (16px)
+                marker.style.transform = `rotate(${angle}deg) translate(${radius}px) rotate(${-angle}deg)`;
+            }
+
             markersDiv.appendChild(marker);
         }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,7 +25,7 @@ function initializeSheet() {
     // Other Traits that don't have a "group"
     createTraitBlock('arete', ['Arete'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
     createTraitBlock('willpower', ['Força de Vontade'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
-    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages' }, { markerType: 'checkbox', customClass: 'vertical-trait' });
+    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages' }, { markerType: 'checkbox', customClass: 'vertical-trait', layout: 'circular' });
 
     // Health Track
     createHealthTrack('health', characterData.health);

--- a/index.html
+++ b/index.html
@@ -107,16 +107,16 @@
 
                 <div class="advantage-column">
                     <div class="advantage-group">
-                        <h3>Arete</h3>
+                        <h3 class="centered-title">Arete</h3>
                         <div id="arete"><!-- Gerado por JS --></div>
                     </div>
                     <div class="advantage-group">
-                        <h3>Força de Vontade</h3>
+                        <h3 class="centered-title">Força de Vontade</h3>
                         <div id="willpower"><!-- Gerado por JS --></div>
                         <div id="willpower-temporary"></div>
                     </div>
                     <div class="advantage-group">
-                        <h3>Quintessência</h3>
+                        <h3 class="centered-title">Quintessência</h3>
                         <div id="quintessence"><!-- Gerado por JS --></div>
                     </div>
                 </div>


### PR DESCRIPTION
This commit addresses several user feedback points:

1.  The titles for Arete, Willpower, and Quintessence are now centered within their respective columns.
2.  The styling for the temporary Willpower checkboxes has been adjusted to align them with the Willpower dots above.
3.  A circular layout has been implemented for the Quintessence markers. The `createTraitBlock` component now supports a `layout: 'circular'` option, which dynamically calculates and applies the necessary CSS transforms to position elements in a circle.