### PR TITLE
fix: Align Willpower dots and temporary checkboxes

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -82,7 +82,8 @@
 
 .checkbox-grid {
     display: flex;
-    gap: 4px;
+    /* The gap is removed to allow the margin-left on the markers to control spacing,
+       just like the .dots container, ensuring the total width is identical. */
     justify-content: center;
     margin-top: 10px;
 }


### PR DESCRIPTION
This commit adjusts the CSS for the temporary Willpower checkboxes to ensure they are perfectly aligned with the Willpower dots above them.

The `gap` property was removed from the `.checkbox-grid` container. The spacing for this grid is now controlled by the `margin-left` property on the `.checkbox-marker` items themselves, making the spacing mechanism identical to the `.dots` container. This ensures both rows of markers have the exact same total width, resolving the alignment issue.