### PR TITLE
feat: Add add/remove functionality for backgrounds

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -116,6 +116,25 @@
     background-color: #3a2d21;
 }
 
+.remove-btn {
+    background-color: transparent;
+    color: #a08c7a;
+    border: none;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 20px;
+    line-height: 20px;
+    cursor: pointer;
+    text-align: center;
+    margin-left: 10px;
+}
+
+.remove-btn:hover {
+    color: #3a2d21;
+    background-color: #e0d8c4;
+}
+
 .circular-container {
     position: relative;
     width: 180px;

--- a/assets/js/components/attributeBlock.js
+++ b/assets/js/components/attributeBlock.js
@@ -79,6 +79,14 @@ function createSingleTraitElement(name, dotCount, initialValue, dataPath, option
     traitDiv.appendChild(nameElement);
     traitDiv.appendChild(markersDiv);
 
+    // Add a remove button for editable traits (backgrounds)
+    if (/^_{5,}$/.test(name)) {
+        const removeBtn = document.createElement('button');
+        removeBtn.className = 'remove-btn';
+        removeBtn.innerHTML = '&times;'; // 'X' symbol
+        traitDiv.appendChild(removeBtn);
+    }
+
     return traitDiv;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,12 +49,25 @@ function setupEventListeners() {
             handleDotClick(event.target);
         } else if (event.target.classList.contains('health-box')) {
             handleHealthBoxClick(event.target);
+        } else if (event.target.classList.contains('remove-btn')) {
+            handleRemoveTrait(event.target);
         }
     });
 
     const addBackgroundBtn = document.getElementById('add-background-btn');
     if (addBackgroundBtn) {
         addBackgroundBtn.addEventListener('click', handleAddBackground);
+    }
+}
+
+/**
+ * Handles removing a trait element from the sheet.
+ * @param {HTMLElement} buttonElement - The remove button that was clicked.
+ */
+function handleRemoveTrait(buttonElement) {
+    const traitElement = buttonElement.closest('.trait');
+    if (traitElement) {
+        traitElement.remove();
     }
 }
 


### PR DESCRIPTION
This commit implements two features for the 'Antecedentes' (Backgrounds) section based on user feedback:

1.  An 'Add' (+) button has been added to allow users to dynamically create new background rows. The JavaScript has been refactored to support creating single trait elements on demand.
2.  A 'Remove' (X) button has been added to each background row, allowing users to delete specific rows.
3.  The placeholder text 'Vantagem' has been removed from the background input fields, leaving them blank by default.