### PR TITLE
fix: Implement interactivity for Willpower and Health boxes

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -80,6 +80,17 @@
     color: #3a2d21;
 }
 
+.health-box.aggravated::after {
+    content: '*';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 1.5em;
+    font-weight: bold;
+    color: #3a2d21;
+}
+
 .checkbox-grid {
     display: flex;
     /* The gap is removed to allow the margin-left on the markers to control spacing,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,6 +51,8 @@ function setupEventListeners() {
             handleHealthBoxClick(event.target);
         } else if (event.target.classList.contains('remove-btn')) {
             handleRemoveTrait(event.target);
+        } else if (event.target.classList.contains('checkbox-marker') && event.target.closest('#willpower-temporary')) {
+            handleTempCheckboxClick(event.target);
         }
     });
 
@@ -223,7 +225,7 @@ function handleHealthBoxClick(clickedBox) {
     const index = parseInt(clickedBox.dataset.index, 10);
     const healthLevel = characterData.health[index];
 
-    // Cycle through states: ok -> bashing -> lethal -> ok
+    // Cycle through states: ok -> bashing -> lethal -> aggravated -> ok
     if (healthLevel.state === 'ok') {
         healthLevel.state = 'bashing';
         clickedBox.classList.add('bashing');
@@ -232,12 +234,24 @@ function handleHealthBoxClick(clickedBox) {
         clickedBox.classList.remove('bashing');
         clickedBox.classList.add('lethal');
     } else if (healthLevel.state === 'lethal') {
-        healthLevel.state = 'ok';
+        healthLevel.state = 'aggravated';
         clickedBox.classList.remove('lethal');
+        clickedBox.classList.add('aggravated');
+    } else if (healthLevel.state === 'aggravated') {
+        healthLevel.state = 'ok';
+        clickedBox.classList.remove('aggravated');
     }
 
     console.log(`Updated health level ${healthLevel.label} to ${healthLevel.state}`);
     console.log(characterData.health);
+}
+
+/**
+ * Handles clicks on the temporary willpower checkboxes.
+ * @param {HTMLElement} checkboxElement - The checkbox element that was clicked.
+ */
+function handleTempCheckboxClick(checkboxElement) {
+    checkboxElement.classList.toggle('filled');
 }
 
 /**


### PR DESCRIPTION
This commit addresses two issues based on user feedback:

1.  The 10 temporary Willpower checkboxes are now interactive. A click handler has been added to toggle their 'filled' state visually.
2.  The Health/Vitality boxes now have a three-stage click cycle. A new 'aggravated' state, represented by an asterisk (*), has been added after the 'lethal' (X) state.