### PR TITLE
feat: Implement Quintessence/Paradox logic and Other Traits layout

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -19,6 +19,16 @@
     border-color: #3a2d21;
 }
 
+.checkbox-marker.quint-filled {
+    background-color: #4a90e2; /* Blue */
+    border-color: #4a90e2;
+}
+
+.checkbox-marker.paradox-filled {
+    background-color: #d0021b; /* Red */
+    border-color: #d0021b;
+}
+
 .checkbox-marker {
     width: 14px;
     height: 14px;
@@ -153,6 +163,14 @@
     margin: 20px auto;
     padding: 0;
     border-radius: 50%;
+}
+
+.paradox-label {
+    text-align: center;
+    font-family: 'Trajan Pro', 'Georgia', serif;
+    text-transform: uppercase;
+    color: #5a442a;
+    margin-top: 10px;
 }
 
 /* Trait Block Styles */

--- a/assets/js/components/attributeBlock.js
+++ b/assets/js/components/attributeBlock.js
@@ -11,7 +11,7 @@
  * @returns {HTMLElement} The created trait element.
  */
 function createSingleTraitElement(name, dotCount, initialValue, dataPath, options) {
-    const { markerType = 'dots', customClass = '', layout = 'linear' } = options;
+    const { markerType = 'dots', customClass = '', layout = 'linear', individualMarkers = false } = options;
 
     // Create the main container for the trait
     const traitDiv = document.createElement('div');
@@ -56,11 +56,16 @@ function createSingleTraitElement(name, dotCount, initialValue, dataPath, option
         // Add a common class for event handling
         marker.classList.add('marker');
 
-        if (i <= initialValue) {
+        if (!individualMarkers && i <= initialValue) {
             marker.classList.add('filled');
         }
-        // Add data-value for later use in event handling
-        marker.dataset.value = i;
+
+        // Add data-value for rating-style markers, or data-index for individual ones
+        if (individualMarkers) {
+            marker.dataset.index = i - 1;
+        } else {
+            marker.dataset.value = i;
+        }
 
         if (layout === 'circular') {
             const angle = (360 / dotCount) * i;

--- a/assets/js/core/characterSheet.js
+++ b/assets/js/core/characterSheet.js
@@ -69,7 +69,7 @@ const characterData = {
         },
         arete: 1,
         willpower: 1,
-        quintessence: 0,
+        quintessence: Array(20).fill('empty'),
     },
     health: [
         { label: 'Escoriado', penalty: 0, state: 'ok' },

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -25,13 +25,14 @@ function initializeSheet() {
     // Other Traits that don't have a "group"
     createTraitBlock('arete', ['Arete'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
     createTraitBlock('willpower', ['Força de Vontade'], 10, 1, { category: 'advantages' }, { customClass: 'vertical-trait' });
-    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages' }, { markerType: 'checkbox', customClass: 'vertical-trait', layout: 'circular' });
+    createTraitBlock('quintessence', ['Quintessência'], 20, 0, { category: 'advantages', group: 'quintessence' }, { markerType: 'checkbox', customClass: 'vertical-trait', layout: 'circular', individualMarkers: true });
 
     // Health Track
     createHealthTrack('health', characterData.health);
 
     // Other Traits
-    createBlankLines('other-traits', 4);
+    const otherTraits = Array(5).fill('___________');
+    createTraitBlock('other-traits', otherTraits, 5, 0, { category: 'advantages', group: 'other-traits' });
 
     // Add temporary willpower checkboxes
     createCheckboxGrid('willpower-temporary', 10);
@@ -53,6 +54,8 @@ function setupEventListeners() {
             handleRemoveTrait(event.target);
         } else if (event.target.classList.contains('checkbox-marker') && event.target.closest('#willpower-temporary')) {
             handleTempCheckboxClick(event.target);
+        } else if (event.target.classList.contains('marker') && event.target.closest('#quintessence')) {
+            handleQuintessenceClick(event.target);
         }
     });
 
@@ -252,6 +255,39 @@ function handleHealthBoxClick(clickedBox) {
  */
 function handleTempCheckboxClick(checkboxElement) {
     checkboxElement.classList.toggle('filled');
+}
+
+/**
+ * Handles clicks on the Quintessence markers.
+ * @param {HTMLElement} element - The marker element that was clicked.
+ */
+function handleQuintessenceClick(element) {
+    // Ensure we are only acting on the markers themselves
+    if (!element.classList.contains('marker')) return;
+
+    const index = parseInt(element.dataset.index, 10);
+    if (isNaN(index)) return;
+
+    const currentState = characterData.advantages.quintessence[index];
+    let nextState;
+
+    // Cycle through states: empty -> quintessence -> paradox -> empty
+    if (currentState === 'empty') {
+        nextState = 'quintessence';
+        element.classList.add('quint-filled');
+    } else if (currentState === 'quintessence') {
+        nextState = 'paradox';
+        element.classList.remove('quint-filled');
+        element.classList.add('paradox-filled');
+    } else { // currentState is 'paradox'
+        nextState = 'empty';
+        element.classList.remove('paradox-filled');
+    }
+
+    // Update the data model
+    characterData.advantages.quintessence[index] = nextState;
+    console.log(`Updated Quintessence point ${index} to ${nextState}`);
+    console.log(characterData.advantages.quintessence);
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -121,6 +121,7 @@
                     <div class="advantage-group">
                         <h3 class="centered-title">Quintessência</h3>
                         <div id="quintessence"><!-- Gerado por JS --></div>
+                        <p class="paradox-label">Paradoxo</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
This commit introduces several new features based on user feedback:

1.  **Quintessence/Paradox:**
    - A 'Paradoxo' label is added below the Quintessence circle.
    - The Quintessence checkboxes are now individually clickable and cycle through three states: empty, blue (Quintessence), and red (Paradox).
    - The data model has been updated to support this individual state tracking.

2.  **Other Traits:**
    - The 'Outras Características' section is now rendered as a list of 5 editable rows, each with 5 rating dots, similar to the 'Antecedentes' section.