### PR TITLE
fix: Correct event listener logic for Quintessence

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,16 +46,17 @@ function setupEventListeners() {
     if (!sheet) return;
 
     sheet.addEventListener('click', (event) => {
-        if (event.target.classList.contains('marker')) {
+        // More specific checks must come before general ones.
+        if (event.target.classList.contains('marker') && event.target.closest('#quintessence')) {
+            handleQuintessenceClick(event.target);
+        } else if (event.target.classList.contains('checkbox-marker') && event.target.closest('#willpower-temporary')) {
+            handleTempCheckboxClick(event.target);
+        } else if (event.target.classList.contains('marker')) {
             handleDotClick(event.target);
         } else if (event.target.classList.contains('health-box')) {
             handleHealthBoxClick(event.target);
         } else if (event.target.classList.contains('remove-btn')) {
             handleRemoveTrait(event.target);
-        } else if (event.target.classList.contains('checkbox-marker') && event.target.closest('#willpower-temporary')) {
-            handleTempCheckboxClick(event.target);
-        } else if (event.target.classList.contains('marker') && event.target.closest('#quintessence')) {
-            handleQuintessenceClick(event.target);
         }
     });
 


### PR DESCRIPTION
This commit fixes a bug in the main event listener where clicks on Quintessence markers were being incorrectly handled by the generic marker handler (`handleDotClick`) instead of the specific `handleQuintessenceClick` function.

The `if/else if` chain in the event listener has been reordered to ensure that the more specific check for Quintessence markers is evaluated before the general check for all markers. This routes the event to the correct handler and restores the intended three-state click functionality (empty -> blue -> red -> empty).