### PR TITLE
feat: Add dynamic row functionality to all skill sections

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -119,7 +119,7 @@
     align-items: center;
 }
 
-.add-btn {
+.add-trait-btn {
     background-color: #5a442a;
     color: #f5eeda;
     border: 1px solid #3a2d21;
@@ -133,7 +133,7 @@
     font-weight: bold;
 }
 
-.add-btn:hover {
+.add-trait-btn:hover {
     background-color: #3a2d21;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -57,13 +57,16 @@ function setupEventListeners() {
             handleHealthBoxClick(event.target);
         } else if (event.target.classList.contains('remove-btn')) {
             handleRemoveTrait(event.target);
+        } else if (event.target.classList.contains('add-trait-btn')) {
+            const button = event.target;
+            const targetId = button.dataset.target;
+            const dataPath = {
+                category: button.dataset.category,
+                group: button.dataset.group
+            };
+            handleAddTrait(targetId, dataPath);
         }
     });
-
-    const addBackgroundBtn = document.getElementById('add-background-btn');
-    if (addBackgroundBtn) {
-        addBackgroundBtn.addEventListener('click', handleAddBackground);
-    }
 }
 
 /**
@@ -78,21 +81,23 @@ function handleRemoveTrait(buttonElement) {
 }
 
 /**
- * Handles adding a new background trait to the sheet.
+ * Handles adding a new trait to the sheet.
+ * @param {string} targetId - The ID of the container to add the trait to.
+ * @param {object} dataPath - The path to the data in the character model.
  */
-function handleAddBackground() {
-    const backgroundsContainer = document.getElementById('backgrounds');
-    if (!backgroundsContainer) return;
+function handleAddTrait(targetId, dataPath) {
+    const container = document.getElementById(targetId);
+    if (!container) return;
 
-    const newBackground = createSingleTraitElement(
+    const newTrait = createSingleTraitElement(
         '___________', // Name for a new blank input
         5,             // dotCount
         0,             // initialValue
-        { category: 'advantages', group: 'backgrounds' }, // dataPath
+        dataPath,      // dataPath
         {}             // options
     );
 
-    backgroundsContainer.appendChild(newBackground);
+    container.appendChild(newTrait);
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -74,15 +74,24 @@
             <h2>Habilidades</h2>
             <div class="abilities">
                 <div class="ability-group">
-                    <h3>Talentos</h3>
+                    <div class="advantage-title-container">
+                        <h3>Talentos</h3>
+                        <button class="add-trait-btn" data-target="talents" data-category="abilities" data-group="talents">+</button>
+                    </div>
                     <div id="talents"><!-- Gerado por JS --></div>
                 </div>
                 <div class="ability-group">
-                    <h3>Perícias</h3>
+                    <div class="advantage-title-container">
+                        <h3>Perícias</h3>
+                        <button class="add-trait-btn" data-target="skills" data-category="abilities" data-group="skills">+</button>
+                    </div>
                     <div id="skills"><!-- Gerado por JS --></div>
                 </div>
                 <div class="ability-group">
-                    <h3>Conhecimentos</h3>
+                    <div class="advantage-title-container">
+                        <h3>Conhecimentos</h3>
+                        <button class="add-trait-btn" data-target="knowledges" data-category="abilities" data-group="knowledges">+</button>
+                    </div>
                     <div id="knowledges"><!-- Gerado por JS --></div>
                 </div>
             </div>
@@ -101,10 +110,13 @@
                 <div class="advantage-group">
                     <div class="advantage-title-container">
                         <h3>Antecedentes</h3>
-                        <button id="add-background-btn" class="add-btn">+</button>
+                        <button class="add-trait-btn" data-target="backgrounds" data-category="advantages" data-group="backgrounds">+</button>
                     </div>
                     <div id="backgrounds"><!-- Gerado por JS --></div>
-                    <h3 class="other-traits-title">Outras Características</h3>
+                    <div class="advantage-title-container">
+                        <h3 class="other-traits-title">Outras Características</h3>
+                        <button class="add-trait-btn" data-target="other-traits" data-category="advantages" data-group="other-traits">+</button>
+                    </div>
                     <div id="other-traits"><!-- Gerado por JS --></div>
                 </div>
 


### PR DESCRIPTION
This commit generalizes the 'add/remove' row functionality previously implemented for 'Antecedentes' and applies it to all Habilidades (Talentos, Perícias, Conhecimentos) and to the 'Outras Características' section.

- A generic `handleAddTrait` function has been created.
- The event listener now uses a single handler for all 'add' buttons, using `data-*` attributes to determine the target section.
- The HTML has been updated to include '+' buttons for all specified sections.