### PR TITLE
fix: Align dots in dynamically added trait rows

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -191,6 +191,9 @@
     flex-grow: 1;
     margin-right: 10px;
     font-size: 1em; /* Ensure consistent font size */
+    padding: 2px 0; /* Consistent padding */
+    height: 25px; /* Consistent height */
+    box-sizing: border-box; /* Consistent box model */
 }
 
 .trait-input {


### PR DESCRIPTION
This commit fixes a CSS issue where the rating dots in dynamically added rows (which use an <input> field) would not be vertically aligned with the dots in the original, static rows (which use a <label> element).

The fix normalizes the styling for both `.trait-label` and `.trait-input` selectors by giving them a consistent height, padding, and box-sizing. This ensures all trait rows have the same height, resolving the alignment problem.