### PR TITLE
fix: Align dots in dynamically added trait rows

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -194,11 +194,12 @@
     padding: 2px 0; /* Consistent padding */
     height: 25px; /* Consistent height */
     box-sizing: border-box; /* Consistent box model */
+    border-bottom: 1px solid transparent; /* Add transparent border to normalize height */
 }
 
 .trait-input {
-    border: none;
-    border-bottom: 1px solid #3a2d21;
+    border: none; /* Reset border to be sure */
+    border-bottom: 1px solid #3a2d21; /* Apply visible border only to input */
     background-color: transparent;
     font-family: 'Georgia', serif;
     padding: 2px 0; /* Adjust padding */


### PR DESCRIPTION
This commit fixes a persistent CSS issue where the rating dots in dynamically added rows (which use an <input> field) would not be vertically aligned with the dots in the original, static rows (which use a <label> element).

The root cause was the 1px `border-bottom` on the input field, which was not present on the label, causing a slight height difference.

The fix makes the `.trait-label` and `.trait-input` elements structurally identical by giving the label a transparent `border-bottom` of the same width. This ensures all trait rows have the exact same height, permanently resolving the alignment problem.