### PR TITLE
feat: Adiciona data/ ao gitignore e remove arquivos desnecessários

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Cargo.lock
 # Arquivos temporários do Sistema Operacional
 .DS_Store
 Thumbs.db
+
+# Local data
+/data/


### PR DESCRIPTION
Atualiza o arquivo .gitignore para ignorar a pasta `data/` que continha arquivos de banco de dados locais.

Adicionalmente, instruí o usuário a remover as pastas `target/` e `data/` do índice do Git, que foram adicionadas acidentalmente ao repositório. Isso limpa o estado atual do repositório, embora o histórico ainda contenha os arquivos grandes.